### PR TITLE
fixes bug where tracked food item copies reference to repo items

### DIFF
--- a/src/components/food-item/index.jsx
+++ b/src/components/food-item/index.jsx
@@ -3,11 +3,6 @@ import { useState } from "react"
 const FoodItem = (props) => {
 
     //====== Component State ======
-
-    /**
-     * State variable to dictate which template of component should be rendered 
-     * @param {("repository"|"tracked"|"management")} 
-     */
     const [useCase, setUseCase] = useState('repository') 
 
     //====== Business Logic and Variables ======
@@ -24,7 +19,6 @@ const FoodItem = (props) => {
     return (
         <div className="box">
             <ul>
-            <li>ID: {foodItem.id}</li>
             <li className="subtitle has-text-centered">{foodItem.name}</li>
             <li>Details:</li>
             <li>- Energy: {foodItem.energy}kj per {foodItem.unit}</li>

--- a/src/functions/daily-tracker.js
+++ b/src/functions/daily-tracker.js
@@ -6,7 +6,7 @@
 /**
  * 
  */
-export const createFoodFactory = (name, energy, weight, protein, fats, carbs) => {
+export const createFoodFactory = (id, name, energy, weight, protein, fats, carbs) => {
     return {
         // getName() {return name},
         // getEnergy() {return energy},
@@ -14,6 +14,7 @@ export const createFoodFactory = (name, energy, weight, protein, fats, carbs) =>
         // getProtein() {return protein},
         // getFats() {return fats},
         // getCarbs() {return carbs}
+        id: id,
         name: name,
         energy: energy,
         weight: weight,
@@ -48,36 +49,62 @@ export const createFoodFactory = (name, energy, weight, protein, fats, carbs) =>
  * modifies macros and energy of food based on serving size selected by user
  * @param {object} foodItem food item object selected by user
  * @param {number} servingInput serving size desired by user (in grams/litre/whole)
- * @return {object} returns a new food item with new energy and macro info based on the serving size selected by user
+ * @return {object} returns a new food item without an ID, but with new energy and macro info based on the serving size selected by user
  */
 export const calcEnergyAndMacrosByServing = (foodItem, servingInput) => {
 
-    // extract properties from food item
-    let {energy, unit, serving, macros} = foodItem
+    // console.log(foodItem)
+    console.log(servingInput)
 
-    // test to see if destructures correctly
-    // console.log(energy, unit, serving, macros)
+    // extract properties from food item
+    let {name, energy, unit, category, serving, macros} = foodItem
 
     if (servingInput) {
         
         // extract unit of measurement from foodItem's unit property
         const [servingSize, servingUnit] = unit.split("-")
 
-        // test to print out energy before conversion:
-        //console.log(`${unit} of ${foodItem.name} has: - ${energy} kj \n- Protein: ${macros.protein}g \n- Fats: ${macros.fats}g \n- Carbs: ${macros.carbohydrates}g`)
+        /*
+            foodItem.energy = helperEnergyMacroCalculation(energy, servingSize, servingInput)
+            foodItem.macros.protein = helperEnergyMacroCalculation(macros.protein, servingSize, servingInput)
+            foodItem.macros.fats = helperEnergyMacroCalculation(macros.fats, servingSize, servingInput)
+            foodItem.macros.carbohydrates = helperEnergyMacroCalculation(macros.carbohydrates, servingSize, servingInput)
 
-        // calc energy and macros based of user's serving input
-        foodItem.energy = helperEnergyMacroCalculation(energy, servingSize, servingInput)
-        foodItem.macros.protein = helperEnergyMacroCalculation(macros.protein, servingSize, servingInput)
-        foodItem.macros.fats = helperEnergyMacroCalculation(macros.fats, servingSize, servingInput)
-        foodItem.macros.carbohydrates = helperEnergyMacroCalculation(macros.carbohydrates, servingSize, servingInput)
+            foodItem.unit =  `${servingInput}-${servingUnit}`
+        */
 
-        // replace old serving size with new serving size
-        foodItem.unit =  `${servingInput}-${servingUnit}`
+        const createdFoodItem = {
+            name: name,
+            // calc energy and macros based of user's serving input
+            energy: helperEnergyMacroCalculation(energy, servingSize, servingInput),
+            // replace old serving size with new serving size
+            unit: `${servingInput}-${servingUnit}`,
+            category: category,
+            serving: serving,
+            macros: {
+                protein: helperEnergyMacroCalculation(macros.protein, servingSize, servingInput),
+                fats: helperEnergyMacroCalculation(macros.fats, servingSize, servingInput),
+                carbohydrates: helperEnergyMacroCalculation(macros.carbohydrates, servingSize, servingInput)
+            }, 
+        }
 
-        return foodItem
+        console.log(createdFoodItem)
+
+        return createdFoodItem
         
-    } else {
-        return foodItem
+    } 
+    else {
+        return {
+            name: name,
+            energy: energy,
+            unit: unit,
+            category: category,
+            serving: serving,
+            macros: {
+                protein: macros.protein,
+                fats: macros.fats,
+                carbohydrates: macros.carbohydrates
+            }, 
+        }
     }
 }

--- a/src/pages/daily-tracker.jsx
+++ b/src/pages/daily-tracker.jsx
@@ -51,7 +51,7 @@ const DailyTracker = () => {
     /**
      * Updates the tracked energy and macro-nutrient values inside the state of page/component
      * @param {Object} foodItem FoodItemObject: {id, name, energy, unit, category, serving, macros}
-     * @returns {null}
+     * @returns {null} null
      */
     const updateTrackerDisplay = (foodItem) => {
 
@@ -77,47 +77,24 @@ const DailyTracker = () => {
 
         foodRepository.forEach(foodItem => {
             if (foodItem.id === selectedId) {
-                //selectedFood = foodItem
+                
+                selectedFood = foodItem
 
-                const {name, energy, unit, category, serving, macros} = foodItem
+                console.log(selectedFood)
 
-                selectedFood = {
-                    name: name,
-                    energy: energy,
-                    unit: unit,
-                    category: category,
-                    serving: serving,
-                    macros: macros
-                }
-            }
+                // helper functions
+                const calculatedFoodItem = calcEnergyAndMacrosByServing(selectedFood, selectedServing)
+                updateTrackerDisplay(calculatedFoodItem) 
+
+                // set Id and append selectedFood to array in state
+                calculatedFoodItem.id = trackedFoodItems.length
+                setFoodItems([...trackedFoodItems, calculatedFoodItem])
+
+                return true
+
+            } else 
+                return false
         });
-
-        if (selectedFood) {
-
-            // helper functions
-            calcEnergyAndMacrosByServing(selectedFood, selectedServing)
-            updateTrackerDisplay(selectedFood) 
-
-            // set Id and append selectedFood to array in state
-            selectedFood.id = trackedFoodItems.length
-            setFoodItems([...trackedFoodItems, selectedFood])
-
-            return true
-        } else 
-            return false
-    }
-
-    const mockFoodItem = {
-        name: "Sweet Potato",
-        energy: 360,
-        unit: "100-grams",
-        category: "starch",
-        serving: "30-grams",
-        macros: {
-            protein: 1.6,
-            fats: 0.2,
-            carbohydrates: 20
-        }
     }
 
     return (

--- a/src/service/daily-tracker-service.js
+++ b/src/service/daily-tracker-service.js
@@ -1,0 +1,3 @@
+const DailyTrackerService = {
+    
+}


### PR DESCRIPTION
fixes bug inside 'daily-tracker.jsx' page inside "trackFoodItem" function

Problem:
- FoodItem from repo-list was added to tracked-items instead of new item created being added, thus resulting in incorrect item being added and errors in calculation, as well mutations inside of state

Fixes:
- new FoodItem returned from calcEnergyAndMacrosByServing() was not assigned to a variable
- updateTrackerDisplay was given incorrect FoodItem as argument
- setFoodItem() also appended incorrect FoodItem to state